### PR TITLE
fix - button doesn't work when multiple react-upload-file exists in single page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "author": "Warrior!",
   "license": "MIT",
   "dependencies": {
-    "react": "^15.4.1"
+    "react": "^15.4.1",
+    "react-dom": "^15.5.4"
   },
   "devDependencies": {
     "babel-core": "^6.18.2",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
  */
 
 import React, { PropTypes, Component } from 'react';
+import ReactDOM from 'react-dom';
 
 export default class ReactUploadFile extends Component {
   static propTypes = {
@@ -82,8 +83,8 @@ export default class ReactUploadFile extends Component {
     currentXHRId: 0,
   };
 
-  componentDidMount() {
-    this.input = document.querySelector('[name=ajax-upload-file-input]');
+  componentDidMount = () => {
+    this.input = ReactDOM.findDOMNode(this).querySelector('[name=ajax-upload-file-input]');
   }
 
   /* trigger input's click*/

--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ export default class ReactUploadFile extends Component {
       <div style={{ display: 'inline-block' }}>
         { chooseFileButton }
         { uploadFileButton }
-      < /div>
+      </div>
     );
   }
 }


### PR DESCRIPTION
+ fix typo

react-upload-file create all file input elements in same name `ajax-upload-file-input`. It occurs all of mounted react-upload-file links with first created `ajax-upload-file-input` input.

to avoid this bug, find file input from descendants, not document.